### PR TITLE
Require there to always be 1 administrator

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -146,8 +146,8 @@ class PagesController < ApplicationController
 
   def remove_permissions
     @user = User.find(params[:format])
-    if @user.email == 'bramirez@umass.edu'
-      redirect_to admin_path, alert: "Permission could not be removed. Brian is God."
+    if User.where(user_type: "admin").length == 1
+      redirect_to admin_path, alert: "Unable to remove permissions. There must be at least 1 administrator."
     else
       @user.user_type = 'attendee'
       @user.save


### PR DESCRIPTION
As per #47 there is now no way to remove the last administrator from Dashboard