### PR TITLE
Fix duplicate exit on alert

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -146,8 +146,8 @@ class PagesController < ApplicationController
 
   def remove_permissions
     @user = User.find(params[:format])
-    if @user.email == 'bramirez@umass.edu'
-      redirect_to admin_path, alert: "Permission could not be removed. Brian is God."
+    if User.where(user_type: "admin").length == 1
+      redirect_to admin_path, alert: "Unable to remove permissions. There must be at least 1 administrator."
     else
       @user.user_type = 'attendee'
       @user.save

--- a/app/views/emails/new.html.erb
+++ b/app/views/emails/new.html.erb
@@ -1,7 +1,7 @@
 <h1>New Email</h1>
 
 <div class="alert alert-dismissible alert-info">
-  <button type="button" class="close" data-dismiss="alert">&times;</button>
+  <button type="button" class="close" data-dismiss="alert"></button>
   <strong>Just FYI:</strong> This email will not be sent automatically. Once you create the email you will have to preview it and then send it.
 </div>
 


### PR DESCRIPTION
Removed duplicate the duplicate x button as per #45 

This is caused by providing any arguments inside the HTML button tag. I did a document-wide search for other instances, but didn't find any.

If this appears again, simply remove anything inside the button tag
<button class="close" data-dismiss="alert"></button>