### PR TITLE
Remove duplicate x button

### DIFF
--- a/app/views/emails/new.html.erb
+++ b/app/views/emails/new.html.erb
@@ -1,7 +1,7 @@
 <h1>New Email</h1>
 
 <div class="alert alert-dismissible alert-info">
-  <button type="button" class="close" data-dismiss="alert">&times;</button>
+  <button type="button" class="close" data-dismiss="alert"></button>
   <strong>Just FYI:</strong> This email will not be sent automatically. Once you create the email you will have to preview it and then send it.
 </div>
 


### PR DESCRIPTION
Removed duplicate the duplicate x button as per #45
This is caused by providing any arguments inside the HTML button tag. I did a document-wide search for other instances, but didn't find any.
If this appears again, simply remove anything inside the button tag