### PR TITLE
Fix GitHub link validation

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,6 +11,16 @@ class Project < ApplicationRecord
 	has_attached_file :projectimage,
 										path: 'project/:filename'
 
+
+
+	validates :link,
+            allow_blank: true,
+            if: -> { link.present? },
+            format: { with: /\G[hH][tT][tT][pP][sS]:\/\/.*/,
+                      message: 'Github link must begin with \'https://\'' }
+
+
+
 	validates_attachment :projectimage,
 											 content_type: { content_type: ['image/jpeg', 'image/jpg', 'image/png'],
 																			 message: 'Image type is not supported.' },


### PR DESCRIPTION
Fix GitHub link integration

Now validates URL

Before this, if https:// wasn't supplied it would redirect to dashboard.HackUMass.com/projects/somegithublink